### PR TITLE
Handle YAML files that begin with a BOM

### DIFF
--- a/src/NetEscapades.Configuration.Yaml/YamlConfigurationFileParser.cs
+++ b/src/NetEscapades.Configuration.Yaml/YamlConfigurationFileParser.cs
@@ -20,7 +20,7 @@ namespace NetEscapades.Configuration.Yaml
 
             // https://dotnetfiddle.net/rrR2Bb
             var yaml = new YamlStream();
-            yaml.Load(new StreamReader(input));
+            yaml.Load(new StreamReader(input, detectEncodingFromByteOrderMarks: true));
 
             if (yaml.Documents.Any())
             {

--- a/test/NetEscapades.Configuration.Tests.Common/TestStreamHelpers.cs
+++ b/test/NetEscapades.Configuration.Tests.Common/TestStreamHelpers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Text;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 
@@ -105,10 +106,10 @@ namespace NetEscapades.Configuration.Tests.Common
             }
         }
 
-        public static Stream StringToStream(string str)
+        public static Stream StringToStream(string str, bool withBom = false)
         {
             var memStream = new MemoryStream();
-            var textWriter = new StreamWriter(memStream);
+            var textWriter = new StreamWriter(memStream, new UTF8Encoding(withBom));
             textWriter.Write(str);
             textWriter.Flush();
             memStream.Seek(0, SeekOrigin.Begin);

--- a/test/NetEscapades.Configuration.Yaml.Tests/SequenceTests.cs
+++ b/test/NetEscapades.Configuration.Yaml.Tests/SequenceTests.cs
@@ -213,5 +213,17 @@ namespace NetEscapades.Configuration.Yaml.Tests
             Assert.Equal("bob", indexConfigurationSections[4].Key);
             Assert.Equal("hello", indexConfigurationSections[5].Key);
         }
+
+        [Fact]
+        public void FilesWithByteOrderMarkerAreParsedCorrectly()
+        {
+            var yaml = "setting1: '1'\nsetting2: '2'";
+
+            var yamlConfigSource = new YamlConfigurationProvider(new YamlConfigurationSource());
+            yamlConfigSource.Load(TestStreamHelpers.StringToStream(yaml, withBom: true));
+
+            Assert.Equal("1", yamlConfigSource.Get("setting1"));
+            Assert.Equal("2", yamlConfigSource.Get("setting2"));
+        }
     }
 }


### PR DESCRIPTION
Otherwise the BOM character will be considered part of the first YAML line.

This can lead to subtle bugs. For example in such a file:
```yaml
[BOM]someconfig: a
otherconfig: b
```
`someconfig` would silently fail to be mapped to config, whereas `otherconfig` would work.