### PR TITLE
YamlDotNet dependency version fix

### DIFF
--- a/src/NetEscapades.Configuration.Yaml/NetEscapades.Configuration.Yaml.csproj
+++ b/src/NetEscapades.Configuration.Yaml/NetEscapades.Configuration.Yaml.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="4.2.1" />
+    <PackageReference Include="YamlDotNet" Version="[4.2.1,)" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">


### PR DESCRIPTION
NuGet package description declares YamlDotNet >= 4.2.1
but in csproj file specified version of YamlDotNet=4.2.1

this change will fix it.