### PR TITLE
Supporting null values

### DIFF
--- a/src/NetEscapades.Configuration.Yaml/YamlConfigurationFileParser.cs
+++ b/src/NetEscapades.Configuration.Yaml/YamlConfigurationFileParser.cs
@@ -66,7 +66,7 @@ namespace NetEscapades.Configuration.Yaml
                 throw new FormatException(Resources.FormatError_KeyIsDuplicated(currentKey));
             }
 
-            _data[currentKey] = yamlValue.Value;
+            _data[currentKey] = IsNullValue(yamlValue) ? null : yamlValue.Value;
             ExitContext();
         }
 
@@ -116,6 +116,17 @@ namespace NetEscapades.Configuration.Yaml
         {
             _context.Pop();
             _currentPath = ConfigurationPath.Combine(_context.Reverse());
+        }
+
+        private bool IsNullValue(YamlScalarNode yamlValue)
+        {
+            return yamlValue.Style == YamlDotNet.Core.ScalarStyle.Plain
+                && (
+                    yamlValue.Value == "~"
+                    || yamlValue.Value == "null"
+                    || yamlValue.Value == "Null"
+                    || yamlValue.Value == "NULL"
+                );
         }
     }
 }

--- a/test/NetEscapades.Configuration.Yaml.Tests/YamlConfigurationTests.cs
+++ b/test/NetEscapades.Configuration.Yaml.Tests/YamlConfigurationTests.cs
@@ -57,6 +57,45 @@ namespace NetEscapades.Configuration.Yaml
         }
 
         [Fact]
+        public void LoadMethodCanHandleNullValue()
+        {
+            var yaml = @"
+                nullValue1: null
+                nullValue2: Null
+                nullValue3: NULL
+                nullValue4: ~
+            ";
+
+            var yamlConfigSrc = LoadProvider(yaml);
+            Assert.Null(yamlConfigSrc.Get("nullValue1"));
+            Assert.Null(yamlConfigSrc.Get("nullValue2"));
+            Assert.Null(yamlConfigSrc.Get("nullValue3"));
+            Assert.Null(yamlConfigSrc.Get("nullValue4"));
+        }
+
+        [Fact]
+        public void OverrideWithNullValue()
+        {
+            var yaml1 = @"
+                firstname: test
+                ";
+
+            var yaml2 = @"
+                firstname: null
+                ";
+
+            var yamlConfigSource1 = new YamlConfigurationSource { FileProvider = TestStreamHelpers.StringToFileProvider(yaml1) };
+            var yamlConfigSource2 = new YamlConfigurationSource { FileProvider = TestStreamHelpers.StringToFileProvider(yaml2) };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.Add(yamlConfigSource1);
+            configurationBuilder.Add(yamlConfigSource2);
+            var config = configurationBuilder.Build();
+
+            Assert.Null(config["firstname"]);
+        }
+
+        [Fact]
         public void SupportAndIgnoreComments()
         {
             var yaml = @"# Comments 

--- a/test/NetEscapades.Configuration.Yaml.Tests/YamlConfigurationTests.cs
+++ b/test/NetEscapades.Configuration.Yaml.Tests/YamlConfigurationTests.cs
@@ -57,6 +57,26 @@ namespace NetEscapades.Configuration.Yaml
         }
 
         [Fact]
+        public void LoadMethodCanHandleNullInObject()
+        {
+            var yaml = @"
+                firstname: test
+                test.suffix: ~
+                test.last.name: ''
+                residential.address: 
+                  street.name: Something street
+                  zipcode: null
+                ";
+            var yamlConfigSrc = LoadProvider(yaml);
+
+            Assert.Equal("test", yamlConfigSrc.Get("firstname"));
+            Assert.Null(yamlConfigSrc.Get("test.suffix"));
+            Assert.Equal(string.Empty, yamlConfigSrc.Get("test.last.name"));
+            Assert.Equal("Something street", yamlConfigSrc.Get("residential.address:STREET.name"));
+            Assert.Null(yamlConfigSrc.Get("residential.address:zipcode"));
+        }
+
+        [Fact]
         public void LoadMethodCanHandleNullValue()
         {
             var yaml = @"


### PR DESCRIPTION
The YAML configuration treated null values as strings:

```yml
test1: null
test2: ~
test3: "null"
```

```csharp
// before
"null".Equals(Configuration["test1"]); // true
"~".Equals(Configuration["test2"]); // true
"null".Equals(Configuration["test3"]); // true

// after
Configuration["test1"] == null; // true
Configuration["test2"] == null; // true
"null".Equals(Configuration["test3"]) // true

```

The changes allow for null values to be specified which is useful when unsetting values:

```yml
# config.yml
cache: "redis:6379"

# config.development.yml
cache: null
```