### PR TITLE
Fix #49 in Yaml Extensions

### DIFF
--- a/src/NetEscapades.Configuration.Yaml/NetEscapades.Configuration.Yaml.csproj
+++ b/src/NetEscapades.Configuration.Yaml/NetEscapades.Configuration.Yaml.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>YAML configuration provider implementation to use with Microsoft.Extensions.Configuration.</Description>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <TargetFrameworks>net461;net472;netstandard2.0</TargetFrameworks>
     <AssemblyName>NetEscapades.Configuration.Yaml</AssemblyName>
     <PackageId>NetEscapades.Configuration.Yaml</PackageId>

--- a/src/NetEscapades.Configuration.Yaml/YamlConfigurationExtensions.cs
+++ b/src/NetEscapades.Configuration.Yaml/YamlConfigurationExtensions.cs
@@ -72,21 +72,24 @@ namespace Microsoft.Extensions.Configuration
             {
                 throw new ArgumentException(Resources.FormatError_InvalidFilePath(), nameof(path));
             }
-
-            if (provider == null && Path.IsPathRooted(path))
+            
+            return builder.AddYamlFile(s =>
             {
-                provider = new PhysicalFileProvider(Path.GetDirectoryName(path));
-                path = Path.GetFileName(path);
-            }
-            var source = new YamlConfigurationSource
-            {
-                FileProvider = provider,
-                Path = path,
-                Optional = optional,
-                ReloadOnChange = reloadOnChange
-            };
-            builder.Add(source);
-            return builder;
+                s.FileProvider = provider;
+                s.Path = path;
+                s.Optional = optional;
+                s.ReloadOnChange = reloadOnChange;
+                s.ResolveFileProvider();
+            });
         }
+        
+        /// <summary>
+        /// Adds a YAML configuration source to <paramref name="builder"/>.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="configureSource">Configures the source.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddYamlFile(this IConfigurationBuilder builder, Action<YamlConfigurationSource> configureSource)
+            => builder.Add(configureSource);
     }
 }

--- a/src/NetEscapades.Configuration.Yaml/YamlConfigurationSource.cs
+++ b/src/NetEscapades.Configuration.Yaml/YamlConfigurationSource.cs
@@ -9,7 +9,7 @@ namespace NetEscapades.Configuration.Yaml
     {
         public override IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            FileProvider = FileProvider ?? builder.GetFileProvider();
+            EnsureDefaults(builder);
             return new YamlConfigurationProvider(this);
         }
     }

--- a/src/NetEscapades.Configuration.Yaml/releasenotes.props
+++ b/src/NetEscapades.Configuration.Yaml/releasenotes.props
@@ -1,29 +1,10 @@
 <Project>
   <PropertyGroup>
-    <PackageReleaseNotes Condition="'$(VersionPrefix)' == '2.0.0'">
+    <PackageReleaseNotes Condition="'$(VersionPrefix)' == '2.0.1'">
       <![CDATA[
 Features:
-* Upgrade YamlDotNet to 6.1.2 - this is a breaking change in the dependency as the YamlDotNet.Signed and YamlDotNet packages were merged
-* Update supported frameworks - only supports .NET 461, .NET 472, and .NET Standard 2.0 (dropped support for 1.x)
+* Fix bug #49 causing exception when using an absolute file path for YAML file path, where directory did not exist.
 
-The following values are interpreted as 'null' during parsing (as per v1.1 of the spec http://yaml.org/type/null.html)
-
-```yaml
-nullValue1: Null
-nullValue2: null
-nullValue3: Null
-nullValue4: ~
-```
-
-Yaml is case sensitive, so be aware that the following values are NOT parsed as null. 
-Instead they are parsed as their string equivalent (NuLL, NUll, and empty strings)
-
-```yaml
-notNull1: NuLL
-notNull2: NUll
-notNull3: 
-notNull4: ''
-```
 ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/test/NetEscapades.Configuration.Yaml.Tests/YamlConfigurationExtensionsTests.cs
+++ b/test/NetEscapades.Configuration.Yaml.Tests/YamlConfigurationExtensionsTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
 using NetEscapades.Configuration.Yaml;
 using Xunit;
 
@@ -26,7 +27,7 @@ namespace NetEscapades.Configuration.Yaml
         }
 
         [Fact]
-        public void AddYamlFile_ThrowsIfFileDoesNotExistAtPath()
+        public void AddYamlFile_ThrowsIfFileDoesNotExistAtPathAndIsOptional()
         {
             // Arrange
             var path = "file-does-not-exist.Yaml";
@@ -34,6 +35,28 @@ namespace NetEscapades.Configuration.Yaml
             // Act and Assert
             var ex = Assert.Throws<FileNotFoundException>(() => new ConfigurationBuilder().AddYamlFile(path).Build());
             Assert.StartsWith($"The configuration file '{path}' was not found and is not optional.", ex.Message);
+        }
+        
+        [Fact]
+        public void AddYamlFile_DoesNotThrowIfFileDoesNotExistAndIsOptional()
+        {
+            // Arrange
+            var path = "file-does-not-exist.Yaml";
+
+            // Act and Assert
+            new ConfigurationBuilder().AddYamlFile(path, optional: true).Build();
+        }
+        
+        [Fact]
+        public void AddYamlFile_DoesNotThrowIfAbsolutePathDirectoryDoesNotExist()
+        {
+            // Arrange
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "does", "not", "exist", "file-does-not-exist.Yaml");
+            
+            // Act and Assert
+            new ConfigurationBuilder()
+                .AddYamlFile(path, optional: true)
+                .Build();
         }
     }
 }


### PR DESCRIPTION
Was causing exception when using an absolute file path for YAML file path, where directory did not exist.