### PR TITLE
Add IOptionsMonitor registration to ConfigureValidatableSetting

### DIFF
--- a/src/NetEscapades.Configuration.Validation/ServiceCollectionExtensions.cs
+++ b/src/NetEscapades.Configuration.Validation/ServiceCollectionExtensions.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Configure<TOptions>(configuration);
             services.AddSingleton<TOptions>(ctx => ctx.GetRequiredService<IOptions<TOptions>>().Value);
             services.AddSingleton<IValidatable>(ctx => ctx.GetRequiredService<IOptions<TOptions>>().Value);
+            services.AddScoped<TOptions>(ctx => ctx.GetRequiredService<IOptionsMonitor<TOptions>>().CurrentValue);
+            services.AddScoped<IValidatable>(ctx => ctx.GetRequiredService<IOptionsMonitor<TOptions>>().CurrentValue);
             return services;
         }
     }


### PR DESCRIPTION
When using Options, its quite handy to have some options be able to leverage reloading. Those require being added constructed as Scoped as otherwise they are never reloaded (as we call to CurrentValue).