### PR TITLE
Don't assume that mapping key is a scalar

### DIFF
--- a/src/NetEscapades.Configuration.Yaml/YamlConfigurationStreamParser.cs
+++ b/src/NetEscapades.Configuration.Yaml/YamlConfigurationStreamParser.cs
@@ -36,7 +36,6 @@ namespace NetEscapades.Configuration.Yaml
         private void VisitYamlNodePair(KeyValuePair<YamlNode, YamlNode> yamlNodePair)
         {
             var context = yamlNodePair.Key.ToString();
-
             VisitYamlNode(context, yamlNodePair.Value);
         }
 

--- a/src/NetEscapades.Configuration.Yaml/YamlConfigurationStreamParser.cs
+++ b/src/NetEscapades.Configuration.Yaml/YamlConfigurationStreamParser.cs
@@ -36,6 +36,7 @@ namespace NetEscapades.Configuration.Yaml
         private void VisitYamlNodePair(KeyValuePair<YamlNode, YamlNode> yamlNodePair)
         {
             var context = yamlNodePair.Key.ToString();
+
             VisitYamlNode(context, yamlNodePair.Value);
         }
 

--- a/src/NetEscapades.Configuration.Yaml/YamlConfigurationStreamParser.cs
+++ b/src/NetEscapades.Configuration.Yaml/YamlConfigurationStreamParser.cs
@@ -35,7 +35,7 @@ namespace NetEscapades.Configuration.Yaml
 
         private void VisitYamlNodePair(KeyValuePair<YamlNode, YamlNode> yamlNodePair)
         {
-            var context = ((YamlScalarNode)yamlNodePair.Key).Value;
+            var context = yamlNodePair.Key.ToString();
             VisitYamlNode(context, yamlNodePair.Value);
         }
 


### PR DESCRIPTION
It works the same for scalars because [`YamlScalarNode.ToString`](https://github.com/aaubry/YamlDotNet/blob/8d1a5cb7f1422da7f915c8ca6fcd3a9511e5af9a/YamlDotNet/RepresentationModel/YamlScalarNode.cs#L204) returns `YamlScalarNode.Value` but avoids an exception if key is not a scalar and enables possibility to use complex keys based on other node kinds' `ToString` overrides.